### PR TITLE
feat: more flexibele `--output` socket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ variable.
 odr-padenc -o $IDENTIFIER -t dls.txt -d ./slides
 ```
 
+The `-o` parameter accepts either:
+- An identifier (e.g., `station1`): Creates sockets at `/tmp/station1.padenc` and `/tmp/station1.audioenc`
+- A full path (e.g., `/var/run/radio/station1`): Creates sockets at `/var/run/radio/station1.padenc` and `/var/run/radio/station1.audioenc`
+
 If you generate slides on-the-fly (e.g. content-related slides with album covers), set the `--erase` flag to ensure a
 slide is only transmitted once, and set `--sleep=0` to start slide transmission as soon as the file is created.
 

--- a/src/odr-padenc.cpp
+++ b/src/odr-padenc.cpp
@@ -61,7 +61,9 @@ static void usage(const char* name) {
                     " -s, --sleep=DUR           Wait DUR seconds between each slide. If set to 0, the next slide is inserted just after the previous one\n"
                     "                             has been transmitted. This is useful e.g. for stations that transmit just a logo slide.\n"
                     "                             Default: %d\n"
-                    " -o, --output=IDENTIFIER   Socket to communicate with audio encoder\n"
+                    " -o, --output=IDENTIFIER   Socket to communicate with audio encoder.
+                             If IDENTIFIER contains '/', it's used as a full path.
+                             Otherwise, /tmp/ is prepended for backward compatibility\n"
                     " --dump-current-slide=F1   Write the slide currently being transmitted to the file F1\n"
                     " --dump-completed-slide=F2 Once the slide is transmitted, move the file from F1 to F2\n"
                     " -t, --dls=FILENAME        FIFO or file to read DLS text from.\n"

--- a/src/pad_interface.cpp
+++ b/src/pad_interface.cpp
@@ -47,7 +47,17 @@ void PadInterface::open(const std::string &pad_ident)
     struct sockaddr_un claddr;
     memset(&claddr, 0, sizeof(struct sockaddr_un));
     claddr.sun_family = AF_UNIX;
-    snprintf(claddr.sun_path, sizeof(claddr.sun_path), "/tmp/%s.padenc", m_pad_ident.c_str());
+    
+    size_t last_slash = m_pad_ident.find_last_of('/');
+    if (last_slash != std::string::npos) {
+        // Full path provided, use as-is with .padenc suffix
+        std::string socket_dir = m_pad_ident.substr(0, last_slash);
+        std::string socket_base = m_pad_ident.substr(last_slash + 1);
+        snprintf(claddr.sun_path, sizeof(claddr.sun_path), "%s/%s.padenc", socket_dir.c_str(), socket_base.c_str());
+    } else {
+        // Identifier only, use /tmp/ for backward compatibility
+        snprintf(claddr.sun_path, sizeof(claddr.sun_path), "/tmp/%s.padenc", m_pad_ident.c_str());
+    }
     if (unlink(claddr.sun_path) == -1 and errno != ENOENT) {
         fprintf(stderr, "Unlinking of socket %s failed: %s\n", claddr.sun_path, strerror(errno));
     }
@@ -110,7 +120,17 @@ void PadInterface::send_pad_data(const uint8_t *data, size_t len)
     struct sockaddr_un claddr;
     memset(&claddr, 0, sizeof(struct sockaddr_un));
     claddr.sun_family = AF_UNIX;
-    snprintf(claddr.sun_path, sizeof(claddr.sun_path), "/tmp/%s.audioenc", m_pad_ident.c_str());
+    
+    size_t last_slash = m_pad_ident.find_last_of('/');
+    if (last_slash != std::string::npos) {
+        // Full path provided, use as-is with .audioenc suffix
+        std::string socket_dir = m_pad_ident.substr(0, last_slash);
+        std::string socket_base = m_pad_ident.substr(last_slash + 1);
+        snprintf(claddr.sun_path, sizeof(claddr.sun_path), "%s/%s.audioenc", socket_dir.c_str(), socket_base.c_str());
+    } else {
+        // Identifier only, use /tmp/ for backward compatibility
+        snprintf(claddr.sun_path, sizeof(claddr.sun_path), "/tmp/%s.audioenc", m_pad_ident.c_str());
+    }
 
     vector<uint8_t> message(len + 1);
     message[0] = MESSAGE_PAD_DATA;

--- a/src/pad_interface.h
+++ b/src/pad_interface.h
@@ -33,8 +33,10 @@
 
 class PadInterface {
     public:
-        /*! Create a new PAD data interface that binds to /tmp/pad_ident.padenc and
-         * communicates with ODR-AudioEnc at /tmp/pad_ident.audioenc
+        /*! Create a new PAD data interface that binds to a socket and
+         * communicates with ODR-AudioEnc. If pad_ident contains '/', it's used as a full path.
+         * Otherwise, /tmp/ is prepended for backward compatibility.
+         * Sockets: pad_ident.padenc (this) and pad_ident.audioenc (ODR-AudioEnc)
          */
         void open(const std::string &pad_ident);
 


### PR DESCRIPTION
This implements flexible socket path handling for the `--output` parameter, aligning ODR-PadEnc with the same functionality I recently added to ODR-AudioEnc in [c4f0ba1](https://github.com/Opendigitalradio/ODR-AudioEnc/commit/c4f0ba1c9c909f7c1ac697068197b681cd567beb).

The `--output` parameter now detects whether the input is:
- **A path** (contains `/`) - uses the full path as specified
- **An identifier** (no `/`) - uses `/tmp/` prefix for backward compatibility

This maintains backward compatibility while adding flexibility for modern deployments in containers.